### PR TITLE
Change db param structure

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -38,7 +38,6 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/syndtr/goleveldb/leveldb/util"
 	"gopkg.in/urfave/cli.v1"
-	"database/sql"
 )
 
 var (
@@ -169,13 +168,7 @@ func initGenesis(ctx *cli.Context) error {
 		if err != nil {
 			utils.Fatalf("Failed to open database: %v", err)
 		}
-		// @NOTE:shyft instantiate BlockExplorerDB here
-		connStr := "user=postgres dbname=shyftdb sslmode=disable"
-		blockExplorerDb, err := sql.Open("postgres", connStr)
-		if err != nil {
-			return nil
-		}
-		_, hash, err := core.SetupGenesisBlock(chaindb, genesis, blockExplorerDb)
+		_, hash, err := core.SetupGenesisBlock(chaindb, genesis)
 		if err != nil {
 			utils.Fatalf("Failed to write genesis block: %v", err)
 		}
@@ -321,6 +314,7 @@ func copyDb(ctx *cli.Context) error {
 
 	syncmode := *utils.GlobalTextMarshaler(ctx, utils.SyncModeFlag.Name).(*downloader.SyncMode)
 	dl := downloader.New(syncmode, chainDb, new(event.TypeMux), chain, nil, nil)
+
 	// Create a source peer to satisfy downloader requests from
 	db, err := ethdb.NewLDBDatabase(ctx.Args().First(), ctx.GlobalInt(utils.CacheFlag.Name), 256)
 	if err != nil {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -57,9 +57,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	whisper "github.com/ethereum/go-ethereum/whisper/whisperv5"
 	"gopkg.in/urfave/cli.v1"
-	
-	// @shyft
-	"database/sql"
 )
 
 var (
@@ -1219,7 +1216,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 	var err error
 	chainDb = MakeChainDatabase(ctx, stack)
 
-	config, _, err := core.SetupGenesisBlock(chainDb, MakeGenesis(ctx), nil)
+	config, _, err := core.SetupGenesisBlock(chainDb, MakeGenesis(ctx))
 	if err != nil {
 		Fatalf("%v", err)
 	}
@@ -1252,14 +1249,8 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 	}
 	vmcfg := vm.Config{EnablePreimageRecording: ctx.GlobalBool(VMEnableDebugFlag.Name)}
 	
-	// @NOTE:shyft instantiate BlockExplorerDB here?
-	connStr := "user=postgres dbname=shyftdb sslmode=disable"
-	blockExplorerDb, err := sql.Open("postgres", connStr)
-	if err != nil {
-		return nil, nil
-	}
 	fmt.Println("Calling NewBlock CHAIN in flags.go ******************************")
-	chain, err = core.NewBlockChain(chainDb, blockExplorerDb,cache, config, engine, vmcfg)
+	chain, err = core.NewBlockChain(chainDb,cache, config, engine, vmcfg)
 	if err != nil {
 		Fatalf("Can't create BlockChain: %v", err)
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -46,9 +46,6 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/hashicorp/golang-lru"
 	"gopkg.in/karalabe/cookiejar.v2/collections/prque"
-	
-	// @shyft
-	"database/sql"
 )
 
 var (
@@ -96,7 +93,6 @@ type BlockChain struct {
 	cacheConfig *CacheConfig        // Cache configuration for pruning
 
 	db     ethdb.Database // Low level persistent database to store final content in
-	blockExplorerDb *sql.DB
 
 	triegc *prque.Prque   // Priority queue mapping block numbers to tries to gc
 	gcproc time.Duration  // Accumulates canonical block processing for trie dumping
@@ -141,7 +137,7 @@ type BlockChain struct {
 // NewBlockChain returns a fully initialised block chain using information
 // available in the database. It initialises the default Ethereum Validator and
 // Processor.
-func NewBlockChain(db ethdb.Database, blockExplorerDb *sql.DB, cacheConfig *CacheConfig, chainConfig *params.ChainConfig, engine consensus.Engine, vmConfig vm.Config) (*BlockChain, error) {
+func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *params.ChainConfig, engine consensus.Engine, vmConfig vm.Config) (*BlockChain, error) {
     fmt.Printf("+++++++++++++++++core/blockchain.GO+++++++++++++++++++++++++NewBlockChain()")
 	if cacheConfig == nil {
 		cacheConfig = &CacheConfig{
@@ -159,7 +155,6 @@ func NewBlockChain(db ethdb.Database, blockExplorerDb *sql.DB, cacheConfig *Cach
 		chainConfig:  chainConfig,
 		cacheConfig:  cacheConfig,
 		db:           db,
-		blockExplorerDb: blockExplorerDb,
 		triegc:       prque.New(),
 		stateCache:   state.NewDatabase(db),
 		quit:         make(chan struct{}),
@@ -908,7 +903,7 @@ func (bc *BlockChain) WriteBlockWithState(block *types.Block, receipts []*types.
 		return NonStatTy, err
 	}
 	// @NOTE:SHYFT - Write block data for block explorer
-	if err := shyftdb.WriteBlock(bc.blockExplorerDb, block, receipts); err != nil {
+	if err := shyftdb.WriteBlock(block, receipts); err != nil {
 		return NonStatTy, err
 	}
 

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -28,9 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
-	
-	// @shyft
-	"database/sql"
 )
 
 // So we can deterministically seed different blockchains
@@ -169,9 +166,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 	genblock := func(i int, parent *types.Block, statedb *state.StateDB) (*types.Block, types.Receipts) {
 		// TODO(karalabe): This is needed for clique, which depends on multiple blocks.
 		// It's nonetheless ugly to spin up a blockchain here. Get rid of this somehow.
-	    connStr := "user=postgres dbname=shyftdb sslmode=disable"
-		blockExplorerDb, _ := sql.Open("postgres", connStr)
-		blockchain, _ := NewBlockChain(db, blockExplorerDb,nil, config, engine, vm.Config{})
+		blockchain, _ := NewBlockChain(db, nil, config, engine, vm.Config{})
 		defer blockchain.Stop()
 
 		b := &BlockGen{i: i, parent: parent, chain: blocks, chainReader: blockchain, statedb: statedb, config: config, engine: engine}
@@ -253,9 +248,7 @@ func newCanonical(engine consensus.Engine, n int, full bool) (ethdb.Database, *B
 	gspec := new(Genesis)
 	db, _ := ethdb.NewMemDatabase()
 	genesis := gspec.MustCommit(db)
-	connStr := "user=postgres dbname=shyftdb sslmode=disable"
-	blockExplorerDb, _ := sql.Open("postgres", connStr)
-	blockchain, _ := NewBlockChain(db, blockExplorerDb, nil, params.AllEthashProtocolChanges, engine, vm.Config{})
+	blockchain, _ := NewBlockChain(db, nil, params.AllEthashProtocolChanges, engine, vm.Config{})
 	// Create and inject the requested chain
 	if n == 0 {
 		return db, blockchain, nil

--- a/les/backend.go
+++ b/les/backend.go
@@ -84,7 +84,7 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 	if err != nil {
 		return nil, err
 	}
-	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlock(chainDb, config.Genesis, nil)
+	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlock(chainDb, config.Genesis)
 	if _, isCompat := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !isCompat {
 		return nil, genesisErr
 	}

--- a/shyftDb/db.go
+++ b/shyftDb/db.go
@@ -1,0 +1,31 @@
+package shyftdb
+
+import (
+  	"fmt"
+  	"database/sql"
+)
+
+var blockExplorerDb *sql.DB
+
+func InitDB() (*sql.DB, error){
+	connStr := "user=postgres dbname=shyftdb sslmode=disable"
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		fmt.Println("ERROR OPENING DB, NOT INITIALIZING")
+		fmt.Println(err)
+		return nil, err
+	} else {
+		blockExplorerDb = db
+		return blockExplorerDb, nil
+	}
+}
+
+func DBConnection() (*sql.DB, error) {
+	if (blockExplorerDb == nil) {
+		_, err := InitDB()
+		if(err != nil) {
+			return nil, err
+		}
+	}
+	return blockExplorerDb, nil
+}


### PR DESCRIPTION
This PR restructures how the shyftBlockExplorer db is initialized. It is now no longer passed around with the global blockchain object, it is now only initialized from within the functions that need it. This is to ensure that the prior tests still pass without refactoring.