### PR TITLE
Db pg geth rollback

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -504,22 +504,21 @@ func (bc *BlockChain) Genesis() *types.Block {
 	return bc.genesisBlock
 }
 //GetBlockHashesSinceLastValidBlockHash returns a slice of invalid blockHashes
-func (bc *BlockChain) GetBlockHashesSinceLastValidBlockHash(validHash common.Hash) (blockHashes []common.Hash) {
+func (bc *BlockChain) GetBlockHashesSinceLastValidBlockHash(validHash common.Hash) (blockHashes []common.Hash, bHashes []string) {
 	//bNumber is VALID blockNumber
 	bNumber := bc.hc.GetBlockNumber(validHash)
 	//hNumber is the Current Header Block Number
 	hNumber := bc.hc.CurrentHeader().Number.Uint64()
 	//hash is the current Headers block hash
 	hash := bc.hc.CurrentHeader().Hash()
-	var blocks []*types.Block
 	//Starting at block height bNumber loop until i <= hNumber
 	for i := hNumber; i > bNumber; i-- {
 		block := bc.GetBlock(hash, hNumber)
 		if block == nil {
 			break
 		}
-		//blocks will be a slice of all invalid blocks (carries all block data)
-		blocks = append(blocks, block)
+		//bHashes will be a slice of all invalid block hashs as []string
+		bHashes = append(bHashes, block.Hash().String())
 		//blockHashes will be a slice of all invalid blockhashes this is returned
 		//to be passed into Rollback()
 		blockHashes = append(blockHashes, block.Hash())
@@ -529,7 +528,7 @@ func (bc *BlockChain) GetBlockHashesSinceLastValidBlockHash(validHash common.Has
 		//necessary for GetBlock LN 517
 		hNumber--
 	}
-	return blockHashes
+	return blockHashes, bHashes
 }
 
 // GetBody retrieves a block body (transactions and uncles) from the database by

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -1427,8 +1427,8 @@ func TestGetBlockHashesSinceLastValidBlockHash (t *testing.T) {
 	fmt.Println("VALID BLOCK HEIGHT      ::", blockHeaderToTest.Number)
 	fmt.Println("CURRENT BLOCKHASH       ::", archive.CurrentHeader().Hash().String())
 	fmt.Println("CURRENT BLOCK HEIGHT    ::", archive.CurrentHeader().Number)
-
-	invalidBlockHashes := archive.GetBlockHashesSinceLastValidBlockHash(blockHeaderToTest.Hash())
+	//Need to add PG rollback in this test case
+	invalidBlockHashes, _ := archive.GetBlockHashesSinceLastValidBlockHash(blockHeaderToTest.Hash())
 	archive.ShyftRollback(invalidBlockHashes)
 	var archiveHeight uint64
 	archiveHeight = 1020

--- a/core/sTypes/stypes.go
+++ b/core/sTypes/stypes.go
@@ -50,6 +50,10 @@ type BlockRes struct {
 	Blocks   []SBlock
 }
 
+type BlockHash struct {
+	Hash string
+}
+
 type SAccounts struct {
 	Addr         string
 	Balance      string

--- a/core/shyft_get_utils.go
+++ b/core/shyft_get_utils.go
@@ -124,6 +124,24 @@ func SGetRecentBlock(sqldb *sqlx.DB) string {
 	return string(json)
 }
 
+func SGetRecentBlockHash() string {
+	sqldb, _ := DBConnection()
+	sqlStatement := `SELECT hash FROM blocks WHERE number=(SELECT MAX(number) FROM blocks);`
+	tx, _ := sqldb.Begin()
+	row := sqldb.QueryRow(sqlStatement)
+	tx.Commit()
+	var hash string
+
+	row.Scan(
+		&hash)
+
+	blockhash := stypes.BlockHash{
+		Hash:       hash,
+	}
+	json, _ := json.Marshal(blockhash)
+	return string(json)
+}
+
 func SGetAllTransactionsFromBlock(sqldb *sqlx.DB, blockNumber string) string {
 	var arr stypes.TxRes
 	var txx string

--- a/shyftDb/postgres_setup_test/create_tables_test.psql
+++ b/shyftDb/postgres_setup_test/create_tables_test.psql
@@ -36,12 +36,13 @@ CREATE TABLE IF NOT EXISTS txs (
 CREATE TABLE IF NOT EXISTS accounts (
   addr text primary key unique,
   balance numeric,
-  accountNonce numeric
+  nonce numeric
 );
 
 CREATE TABLE IF NOT EXISTS internalTxs (
   id SERIAL PRIMARY KEY,
   txHash text references txs(txHash),
+  blockHash text references blocks(hash) ON DELETE CASCADE,
   type text,
   to_addr text,
   from_addr text,

--- a/shyft_schema/pg_table_schema.go
+++ b/shyft_schema/pg_table_schema.go
@@ -169,7 +169,7 @@ DELETE FROM internaltxs WHERE blockhash = ANY($1);
 
 // BlockRollback - deletes all blocks whose hash is contained in the array of blockheaders
 const BlockRollback = `
-DELETE FROM block WHERE hash = ANY($1);
+DELETE FROM blocks WHERE hash = ANY($1);
 `
 
 // FindOrCreateAcctStmnt - query to create account if it doesnt exist - and return it if it does


### PR DESCRIPTION
**Changes made in this pull request:**

- Returning blockHash []string for PG rollback
- Connected PG Rollback with Geth Rollback in unit test which is passing
- To be clear, this test checks if Geth and PG are rolled back to the same canonical head

To run the test follow the below commands:
               `cd core`
               `go test -run TestGetBlockHashesSinceLastValidBlockHash`