### PR TITLE
Shrink shyftgeth image size

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To stop Geth, **`crtl+C`** in the terminal window, if you proceed with the start
 To see transactions being submitted on the network see the sendTransactions command in the CLI section of this readme.
 #### Docker Images
 
-Docker Images are available for ShyftGeth and the Postgresql Database which can be used for development and testing. To launch these containers you will need to have docker-compose installed on your computer. Installation instructions for docker-compose are available [here](https://docs.docker.com/install/).
+Two sets of Docker Images are available for ShyftGeth, the Postgresql Database, and the Shyft Blockchain Explorer, which can be used for local development and testnet connection. The development settings are included in docker-compose.yml, the testnet settings are included in docker-compose.production.yml. To launch these containers you will need to have docker-compose installed on your computer. Installation instructions for docker-compose are available [here](https://docs.docker.com/install/).
 
 **To build the images for the first time please run the following command:**
 

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,76 @@
+version: '3'
+services:
+  shyftgeth:
+    build:
+      context: $PWD 
+      dockerfile: docker/production/shyftGeth/Dockerfile
+    ports:
+      - "8545:8545"
+      - "8546:8546"
+      - "31333:31333"
+      - "31333:31333/udp"
+      - "8081:8081"
+    volumes:
+      - ./shyftData:/go/src/ShyftNetwork/go-empyrean/shyftData
+    working_dir: /go/src/ShyftNetwork/go-empyrean
+    depends_on: 
+      - pg
+    networks:
+      - shyftnet
+    command: >
+      sh -c 'cd /go/src/ShyftNetwork/go-empyrean &&
+            ./wait-for.sh pg:5432 &&
+            DBENV=docker export DBENV &&
+            ./shyft-cli/initShyftGeth.sh &&
+            geth --config config.toml --gcmode archive --ws --wsaddr="0.0.0.0" --wsorigins "*" --nat=any --minerthreads 4 --targetgaslimit 80000000 --bootnodes enode://e8e2053ccd176ffd04f663ad675cce7038666b4c0fbadc4bf18ffcef2b75a9482acdbc8a9e9ce649b4a819811636ee946b9963db669f959f1e00e616b8cafa21@18.213.224.80:31333 --bootnodes enode://db9636cf1e8a61c0d55301f4f92b49576f48bc793b87bc23acb2b95a1bfe3ba4404f8ca5ef8fe7539a587bdcecbec72aacfc3c067d426b488ede0afec291a225@18.136.86.171:31333'
+  pg:
+    build: 
+      context: $PWD
+      dockerfile: docker/production/pg/Dockerfile
+    volumes:
+      - ./pg-data:/var/lib/postgresql/data
+    ports:
+      - "8001:5432"
+    networks:
+      - shyftnet
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=docker
+      - POSTGRES_DB=postgres
+  shyft_block_api:
+    build:
+      context: $PWD 
+      dockerfile: docker/production/shyftApi/Dockerfile
+    # volumes:
+    #   - ./shyftBlockExplorerApi:/go/src/github.com/ShyftNetwork/go-empyrean/shyftBlockExplorerApi
+    working_dir: /go/src/github.com/ShyftNetwork/go-empyrean/shyftBlockExplorerApi
+    ports:
+      - "8080:8080"
+    depends_on:
+      - pg
+    networks:
+      - shyftnet
+    command: >
+      sh -c '
+            pwd && govendor remove github.com/ShyftNetwork/go-empyrean/crypto/secp256k1/^ && 
+            govendor fetch github.com/ShyftNetwork/go-empyrean/crypto/secp256k1/^  && 
+            /wait-for.sh pg:5432 &&
+            DBENV=docker export DBENV &&
+            go run -v *.go'
+  shyft_block_ui:
+    build:
+      context: $PWD 
+      dockerfile: docker/production/shyftUi/Dockerfile
+      # volumes:
+      #   - ./shyftBlockExplorerApi:/go/src/github.com/ShyftNetwork/go-empyrean/shyftBlockExplorerApi
+    ports:
+      - "3000:3000"
+    depends_on:
+      - shyft_block_api
+    networks:
+      - shyftnet
+networks:
+  shyftnet:
+    driver: bridge
+  
+

--- a/docker/production/pg/Dockerfile
+++ b/docker/production/pg/Dockerfile
@@ -1,4 +1,6 @@
 FROM postgres:10.4-alpine
 
+COPY ./shyft-cli/postgres_setup/docker_init_user_db.sh /docker-entrypoint-initdb.d/init-db.sh
+
 VOLUME ["/var/lib/postgresql"]
 EXPOSE 5432

--- a/docker/production/shyftGeth/Dockerfile
+++ b/docker/production/shyftGeth/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3-alpine
+FROM golang:1.10.3-alpine AS build-env
 
 # To copy complete directory
 COPY ./ /go/src/github.com/ShyftEthereum/go-empyrean
@@ -10,6 +10,16 @@ RUN \
   cp -v /go/src/github.com/ShyftEthereum/go-empyrean/build/bin/geth /bin && \
   cp -v /go/src/github.com/ShyftEthereum/go-empyrean/build/bin/bootnode /bin 
 
-WORKDIR /go/src/github.com/ShyftEthereum/go-empyrean
+FROM alpine:3.8
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+WORKDIR /go/src/ShyftNetwork/go-empyrean/
+COPY --from=build-env /bin/geth /bin/
+COPY --from=build-env /bin/bootnode /bin/
 
-CMD ["./shyft-cli/initShyftGeth.sh", "./shyft-cli/startShyftGeth.sh"]
+COPY ./config.toml ./
+COPY ./ShyftNetwork.json ./
+COPY ./wait-for.sh ./
+COPY ./shyft-cli/initShyftGeth.sh ./shyft-cli/
+
+CMD ["./shyft-cli/initShyftGeth.sh", "geth --config config.toml"]
+

--- a/shyft_documentation/source/index.html.md
+++ b/shyft_documentation/source/index.html.md
@@ -140,8 +140,7 @@ If you are installing postgresql locally for development on Ubuntu the app assum
 
 To see transactions being submitted on the network see the sendTransactions command in the CLI section of this readme.
 ### Docker Images
-
-Docker Images are available for ShyftGeth and the Postgresql Database which can be used for development and testing. To launch these containers you will need to have docker-compose installed on your computer. Installation instructions for docker-compose are available [here](https://docs.docker.com/install/).
+Two sets of Docker Images are available for ShyftGeth, the Postgresql Database, and the Shyft Blockchain Explorer, which can be used for local development and testnet connection. The development settings are included in docker-compose.yml, the testnet settings are included in docker-compose.production.yml (shyftgeth not mining by default). To launch these containers you will need to have docker-compose installed on your computer. Installation instructions for docker-compose are available [here](https://docs.docker.com/install/).
 
 **To build the images for the first time please run the following command:**
 


### PR DESCRIPTION
Using two-stage build to reduce shyftgeth image size on disk from 1.6 GB to 71 MB, for quicker build and pull from Docker Hub.

REPOSITORY                      TAG                 IMAGE ID            CREATED             SIZE
go-empyrean_shyftgeth           latest              d1db5e5c4db4        29 minutes ago      70.7MB
<none>                          <none>              46f103e69928        29 minutes ago      1.66GB

To connect to testnet:
 docker-compose -f docker-compose.production.yml up
