### PR TITLE
Authenticate Whisper Signers On Message Receipt

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/ShyftNetwork/go-empyrean/accounts/abi/bind"
 	"github.com/ShyftNetwork/go-empyrean/accounts/abi/bind/backends"
-	"github.com/ShyftNetwork/go-empyrean/common"
 	"github.com/ShyftNetwork/go-empyrean/core"
 	"github.com/ShyftNetwork/go-empyrean/crypto"
 	"github.com/ShyftNetwork/go-empyrean/generated_bindings"
@@ -596,24 +595,28 @@ func (sub *TestType) Err() <-chan error {
 }
 
 func TestWhisperChannels(t *testing.T) {
+	stack, err := New(testNodeConfig())
+	if err != nil {
+		t.Fatalf("failed to create protocol stack: %v", err)
+	}
 	var sub *TestType = &TestType{"foo"}
 	messages := make(chan *whisper.Message)
-	whisperChannel := make(chan string)
 
 	// signer of the test messages
 	testAddrA := "0x7dA99dF96259305Ee38c9fA9E9D551118B12eC3b"
 
-	go whisperMessageReceiver(sub, messages, whisperChannel, func(testAddr common.Address) bool {
-		return common.HexToAddress(testAddrA) == testAddr
-	})
+	stack.config.WhisperKeys = append(stack.config.WhisperKeys, testAddrA)
+	stack.config.WhisperSignersContract = ""
+	stack.config.WhisperChannel = make(chan string)
 
+	go stack.whisperMessageReceiver(sub, messages)
 	msg := &whisper.Message{
 		// valid signature for "notablockhash" for the testAddr
 		Payload: []byte("notablockhash--0x5944a150e7cc2d77cd47d94dfe7665c7921768d4eb8a1479026751e7574e70d37a8b5ba5ec55111572ea30a9c9d9504efebdd8311b7b6bad05c4fd48e51bd3841c"),
 	}
 
 	messages <- msg
-	resp := <-whisperChannel
+	resp := <-stack.config.WhisperChannel
 	if "notablockhash" != resp {
 		t.Errorf("result mismatch: have %s, want %s", resp, testAddrA)
 	}


### PR DESCRIPTION
This PR addresses [Issue](https://github.com/ShyftNetwork/go-empyrean/issues/148).

With this modification the node does not need to be restarted in the event of a later deployment of the whisper signers contract. In the event a rollback command is issued the existence of the smart contract is now checked upon message receipt.

Note that for the node to subscribe to the whisper messages one of the following conditions has to be met:

1) The whisper signers contract address has to be included in the config.toml  under [Node] WhisperSIgnersContract= ; or

2) The geth node needs to be started with the --whisperkeys flag - followed by a string list of the public keys of whisper broadcasters.

